### PR TITLE
Model property renaming

### DIFF
--- a/push-sdk/AGClientDeviceInformationImpl.h
+++ b/push-sdk/AGClientDeviceInformationImpl.h
@@ -21,7 +21,7 @@
 @interface AGClientDeviceInformationImpl : NSObject<AGClientDeviceInformation>
 
 /**
- * Convenient method that will encapsulate the configuration params to a dictionary
+ * Convenient method that will encapsulate the configuration params to a JSON object / dictionary
  * ready to be send to the server during the registration request.
  */
 -(NSDictionary *) extractValues;

--- a/push-sdk/AGClientDeviceInformationImpl.m
+++ b/push-sdk/AGClientDeviceInformationImpl.m
@@ -50,7 +50,7 @@
     [values setValue:_alias forKey:@"alias"];
     [values setValue:_category forKey:@"category"];
 
-    [values setValue:_operatingSystem forKey:@"mobileOperatingSystem"];
+    [values setValue:_operatingSystem forKey:@"operatingSystem"];
     [values setValue:_osVersion forKey:@"osVersion"];
     [values setValue:_deviceType forKey:@"deviceType"];
     


### PR DESCRIPTION
As requested in [AGPUSH-229](jira.jboss.org/browse/AGPUSH-229) this PR covers the iOS-side renaming the 'mobileOperatingSystem' field to 'operatingSystem' field.
