### PR TITLE
fix formatting issue with code block in appledoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can use [aerogear-push-helloworld](https://github.com/aerogear/aerogear-push
 
 ## Example Usage
 
-```ObjC
+```
 - (void)application:(UIApplication *)application
 didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
 
@@ -110,7 +110,7 @@ didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
 
 There are no extra hooks for receiving notifications with the AeroGear library. You can use the existing delegate for receiving remote notifications while the application is running, like:
 
-```ObjC
+```
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
   // extract desired value from the dictionary...
 }


### PR DESCRIPTION
during appledoc generation noticed in the generated html a code block with mis-aligned formatting, 
picture of the issue  can be found [here](https://dl.dropboxusercontent.com/u/155050/2014-08-18%2005.57.35%20pm.png)

this PR fixes this align issue
