### PR TITLE
ensure that both prefix/postfix of / char in url will work

### DIFF
--- a/push-sdk-swift/AGDeviceRegistration.swift
+++ b/push-sdk-swift/AGDeviceRegistration.swift
@@ -77,7 +77,7 @@ public class AGDeviceRegistration: NSObject, NSURLSessionTaskDelegate {
             assert(clientInfoObject.variantSecret != nil, "'variantSecret' should be set");
             
             // set up our request
-            let request = NSMutableURLRequest(URL: serverURL.URLByAppendingPathComponent("/rest/registry/device"))
+            let request = NSMutableURLRequest(URL: serverURL.URLByAppendingPathComponent("rest/registry/device"))
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.HTTPMethod = "POST"
             


### PR DESCRIPTION
the prefix / when constructing the URL using URLByAppendingPathComponent should be removed cause in case the user added a trailer / the output is a double // that leads to 404.
Removing the prefix / when calling the method, results in both cases work regardless if the user passed a url with trailer / or not.

[note]
this is not an issue with the obj-c sdk since already we have already [take care of it](https://github.com/aerogear/aerogear-ios-push/blob/master/push-sdk/AGDeviceRegistration.m#L71)
