### PR TITLE
adds support for self signed certificates used on aerogear-push-server

### DIFF
--- a/push-sdk-swift/AGDeviceRegistration.swift
+++ b/push-sdk-swift/AGDeviceRegistration.swift
@@ -148,4 +148,16 @@ public class AGDeviceRegistration: NSObject, NSURLSessionTaskDelegate {
         
         completionHandler(request)
     }
+
+    /**
+    * Provides support for self signed certificates, if the hostname of the aerogear server matches the hostname in the certificate.
+    */
+    public func URLSession(session: NSURLSession, task: NSURLSessionTask, didReceiveChallenge challenge: NSURLAuthenticationChallenge, completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential!) -> Void) {
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust && challenge.protectionSpace.host == serverURL.host! {
+            let credentials = NSURLCredential(forTrust: challenge.protectionSpace.serverTrust!)
+            completionHandler(NSURLSessionAuthChallengeDisposition.UseCredential, credentials)
+        } else {
+            completionHandler(NSURLSessionAuthChallengeDisposition.CancelAuthenticationChallenge, nil)
+        }
+    }
 }


### PR DESCRIPTION
I created a little patch that enables the SDK to register with aerogear-push servers that use self signed SSL certificates or certificates of a ca that is not imported into the iOS keystore.