### PR TITLE
Agios 448.fix.test.taget

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ xcodeproj 'push-sdk.xcodeproj'
 
 platform :ios, '7.0'
 
-target 'push-sdkTests', :exclusive => true do
+target 'pushsdkTests', :exclusive => true do
 	pod 'Kiwi', '2.3.0'
 	pod 'OHHTTPStubs', '3.1.5'
 end

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ To build the library simply run the build script:
 
 The build script will generate a buid folder containing an universal static lib and a framework, sources and documentation are also packaged.
 
-**NOTE** on 64 bits architecture: From Xcode 5.1 release inwards, Apple changes the "Standard Architectures" to also include the arm64 architecture. See "Building" section on the [Xcode 5.1 release notes](https://developer.apple.com/library/mac/releasenotes/DeveloperTools/RN-Xcode/xc5_release_notes/xc5_release_notes.html#//apple_ref/doc/uid/TP40001051-CH2-SW2). When building with Xcode 5.0, the built library will not support 64 bits architecture. **We recommend you to build with Xcode 5.1+**
+The push-sdk.xcodeproject contains two framework targets ```pushsdk``` to build dynamic framework supported from iOS8 and used when runnning unit tests and ```push-sdk``` to building static framework supported from iOS7.
 
+**NOTE** Dynamic framework name should not contain ```-``` symbols.
 
 ## Adding the library to your project 
 

--- a/push-sdk.xcodeproj/project.pbxproj
+++ b/push-sdk.xcodeproj/project.pbxproj
@@ -7,96 +7,73 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1E24316231A94448BF936F03 /* libPods-push-sdkTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 690976179180479293B024D8 /* libPods-push-sdkTests.a */; };
-		482A24EF1B0A189F00CE5BDC /* AGPushAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 482A24EE1B0A189F00CE5BDC /* AGPushAnalytics.m */; };
-		6F53E2BB1768A935001966D8 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F53E2BA1768A935001966D8 /* Security.framework */; };
-		A010C2E51737A58100CFA575 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A010C2E41737A58100CFA575 /* Foundation.framework */; };
-		A010C2F41737A58100CFA575 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A010C2F31737A58100CFA575 /* SenTestingKit.framework */; };
-		A010C2F61737A58100CFA575 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A010C2F51737A58100CFA575 /* UIKit.framework */; };
-		A010C2F71737A58100CFA575 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A010C2E41737A58100CFA575 /* Foundation.framework */; };
-		A010C2FA1737A58100CFA575 /* libpush-sdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A010C2E11737A58100CFA575 /* libpush-sdk.a */; };
-		A010C3001737A58100CFA575 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A010C2FE1737A58100CFA575 /* InfoPlist.strings */; };
-		A010C30D1737A8F300CFA575 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A010C30C1737A8F300CFA575 /* MobileCoreServices.framework */; };
-		A010C30F1737A95A00CFA575 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A010C30E1737A95A00CFA575 /* SystemConfiguration.framework */; };
-		A010C3151737A9ED00CFA575 /* AGDeviceRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = A010C3141737A9ED00CFA575 /* AGDeviceRegistration.m */; };
-		A010C3181737AA2C00CFA575 /* AGDeviceRegistrationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = A010C3171737AA2C00CFA575 /* AGDeviceRegistrationSpec.m */; };
-		A010C31D1737D01000CFA575 /* AGClientDeviceInformationImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = A010C31C1737D00F00CFA575 /* AGClientDeviceInformationImpl.m */; };
-		A03AC14417817BB300FF13A7 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A03AC14217817BA300FF13A7 /* CoreGraphics.framework */; };
+		48289BE91B2EEDF2004AF471 /* pushsdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48289BDE1B2EEDF2004AF471 /* pushsdk.framework */; };
+		48289BFF1B2EEE5D004AF471 /* AeroGearPush.h in Headers */ = {isa = PBXBuildFile; fileRef = 48289BF71B2EEE5D004AF471 /* AeroGearPush.h */; };
+		48289C001B2EEE5D004AF471 /* AGClientDeviceInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 48289BF81B2EEE5D004AF471 /* AGClientDeviceInformation.h */; };
+		48289C011B2EEE5D004AF471 /* AGClientDeviceInformationImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 48289BF91B2EEE5D004AF471 /* AGClientDeviceInformationImpl.h */; };
+		48289C021B2EEE5D004AF471 /* AGClientDeviceInformationImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFA1B2EEE5D004AF471 /* AGClientDeviceInformationImpl.m */; };
+		48289C031B2EEE5D004AF471 /* AGDeviceRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 48289BFB1B2EEE5D004AF471 /* AGDeviceRegistration.h */; };
+		48289C041B2EEE5D004AF471 /* AGDeviceRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFC1B2EEE5D004AF471 /* AGDeviceRegistration.m */; };
+		48289C051B2EEE5D004AF471 /* AGPushAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 48289BFD1B2EEE5D004AF471 /* AGPushAnalytics.h */; };
+		48289C061B2EEE5D004AF471 /* AGPushAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */; };
+		48289C081B2EEE78004AF471 /* AGDeviceRegistrationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */; };
+		5C18F90CC0E512A66E4B5789 /* libPods-pushsdkTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 30277CD3D67E463A98C74ED2 /* libPods-pushsdkTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		A010C2F81737A58100CFA575 /* PBXContainerItemProxy */ = {
+		48289BEA1B2EEDF2004AF471 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A010C2D91737A58100CFA575 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A010C2E01737A58100CFA575;
+			remoteGlobalIDString = 48289BDD1B2EEDF2004AF471;
 			remoteInfo = "push-sdk";
 		};
 /* End PBXContainerItemProxy section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		A010C2DF1737A58100CFA575 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/${PRODUCT_NAME}";
-			dstSubfolderSpec = 16;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
+		30277CD3D67E463A98C74ED2 /* libPods-pushsdkTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-pushsdkTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BFACB4DBB32DE6AB10BCA68 /* Pods-push-sdkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-push-sdkTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-push-sdkTests/Pods-push-sdkTests.release.xcconfig"; sourceTree = "<group>"; };
-		482A24EE1B0A189F00CE5BDC /* AGPushAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGPushAnalytics.m; sourceTree = "<group>"; };
-		482A24F01B0A18D500CE5BDC /* AGPushAnalytics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AGPushAnalytics.h; sourceTree = "<group>"; };
+		48289BDE1B2EEDF2004AF471 /* pushsdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = pushsdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		48289BE11B2EEDF2004AF471 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		48289BE81B2EEDF2004AF471 /* push-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "push-sdkTests.xctest"; path = pushsdkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		48289BEE1B2EEDF2004AF471 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		48289BF71B2EEE5D004AF471 /* AeroGearPush.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AeroGearPush.h; sourceTree = "<group>"; };
+		48289BF81B2EEE5D004AF471 /* AGClientDeviceInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGClientDeviceInformation.h; sourceTree = "<group>"; };
+		48289BF91B2EEE5D004AF471 /* AGClientDeviceInformationImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGClientDeviceInformationImpl.h; sourceTree = "<group>"; };
+		48289BFA1B2EEE5D004AF471 /* AGClientDeviceInformationImpl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGClientDeviceInformationImpl.m; sourceTree = "<group>"; };
+		48289BFB1B2EEE5D004AF471 /* AGDeviceRegistration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGDeviceRegistration.h; sourceTree = "<group>"; };
+		48289BFC1B2EEE5D004AF471 /* AGDeviceRegistration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGDeviceRegistration.m; sourceTree = "<group>"; };
+		48289BFD1B2EEE5D004AF471 /* AGPushAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGPushAnalytics.h; sourceTree = "<group>"; };
+		48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGPushAnalytics.m; sourceTree = "<group>"; };
+		48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGDeviceRegistrationSpec.m; sourceTree = "<group>"; };
 		5F8A96B5477848779F501C0A /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		690976179180479293B024D8 /* libPods-push-sdkTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-push-sdkTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F53E2BA1768A935001966D8 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
-		6FF89BEF18F572B000C19EE6 /* push-sdk-fmwk-info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "push-sdk-fmwk-info.plist"; sourceTree = "<group>"; };
 		8564B376890B868A05FBA59D /* Pods-push-sdkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-push-sdkTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-push-sdkTests/Pods-push-sdkTests.debug.xcconfig"; sourceTree = "<group>"; };
-		A010C2E11737A58100CFA575 /* libpush-sdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libpush-sdk.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		881341938EC0FF4FED20F1A4 /* Pods-pushsdkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pushsdkTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-pushsdkTests/Pods-pushsdkTests.debug.xcconfig"; sourceTree = "<group>"; };
+		99807EBAD8048D94D8FF85A9 /* Pods-pushsdkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pushsdkTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-pushsdkTests/Pods-pushsdkTests.release.xcconfig"; sourceTree = "<group>"; };
 		A010C2E41737A58100CFA575 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		A010C2E81737A58100CFA575 /* push-sdk-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "push-sdk-Prefix.pch"; sourceTree = "<group>"; };
-		A010C2F21737A58100CFA575 /* push-sdkTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "push-sdkTests.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A010C2F31737A58100CFA575 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		A010C2F51737A58100CFA575 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		A010C2FD1737A58100CFA575 /* push-sdkTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "push-sdkTests-Info.plist"; sourceTree = "<group>"; };
-		A010C2FF1737A58100CFA575 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A010C30C1737A8F300CFA575 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		A010C30E1737A95A00CFA575 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
-		A010C3101737A97A00CFA575 /* AeroGearPush.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AeroGearPush.h; sourceTree = "<group>"; };
-		A010C3131737A9ED00CFA575 /* AGDeviceRegistration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGDeviceRegistration.h; sourceTree = "<group>"; };
-		A010C3141737A9ED00CFA575 /* AGDeviceRegistration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGDeviceRegistration.m; sourceTree = "<group>"; };
-		A010C3171737AA2C00CFA575 /* AGDeviceRegistrationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGDeviceRegistrationSpec.m; sourceTree = "<group>"; };
-		A010C3191737B09D00CFA575 /* AGClientDeviceInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGClientDeviceInformation.h; sourceTree = "<group>"; };
-		A010C31B1737D00F00CFA575 /* AGClientDeviceInformationImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGClientDeviceInformationImpl.h; sourceTree = "<group>"; };
-		A010C31C1737D00F00CFA575 /* AGClientDeviceInformationImpl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGClientDeviceInformationImpl.m; sourceTree = "<group>"; };
 		A03AC14217817BA300FF13A7 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		A010C2DE1737A58100CFA575 /* Frameworks */ = {
+		48289BDA1B2EEDF2004AF471 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A010C2E51737A58100CFA575 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A010C2EE1737A58100CFA575 /* Frameworks */ = {
+		48289BE51B2EEDF2004AF471 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A03AC14417817BB300FF13A7 /* CoreGraphics.framework in Frameworks */,
-				6F53E2BB1768A935001966D8 /* Security.framework in Frameworks */,
-				A010C30F1737A95A00CFA575 /* SystemConfiguration.framework in Frameworks */,
-				A010C30D1737A8F300CFA575 /* MobileCoreServices.framework in Frameworks */,
-				A010C2F41737A58100CFA575 /* SenTestingKit.framework in Frameworks */,
-				A010C2F61737A58100CFA575 /* UIKit.framework in Frameworks */,
-				A010C2F71737A58100CFA575 /* Foundation.framework in Frameworks */,
-				A010C2FA1737A58100CFA575 /* libpush-sdk.a in Frameworks */,
-				1E24316231A94448BF936F03 /* libPods-push-sdkTests.a in Frameworks */,
+				48289BE91B2EEDF2004AF471 /* pushsdk.framework in Frameworks */,
+				5C18F90CC0E512A66E4B5789 /* libPods-pushsdkTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -108,15 +85,58 @@
 			children = (
 				8564B376890B868A05FBA59D /* Pods-push-sdkTests.debug.xcconfig */,
 				3BFACB4DBB32DE6AB10BCA68 /* Pods-push-sdkTests.release.xcconfig */,
+				881341938EC0FF4FED20F1A4 /* Pods-pushsdkTests.debug.xcconfig */,
+				99807EBAD8048D94D8FF85A9 /* Pods-pushsdkTests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		48289BDF1B2EEDF2004AF471 /* push-sdk */ = {
+			isa = PBXGroup;
+			children = (
+				48289BF71B2EEE5D004AF471 /* AeroGearPush.h */,
+				48289BF81B2EEE5D004AF471 /* AGClientDeviceInformation.h */,
+				48289BF91B2EEE5D004AF471 /* AGClientDeviceInformationImpl.h */,
+				48289BFA1B2EEE5D004AF471 /* AGClientDeviceInformationImpl.m */,
+				48289BFB1B2EEE5D004AF471 /* AGDeviceRegistration.h */,
+				48289BFC1B2EEE5D004AF471 /* AGDeviceRegistration.m */,
+				48289BFD1B2EEE5D004AF471 /* AGPushAnalytics.h */,
+				48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */,
+				48289BE01B2EEDF2004AF471 /* Supporting Files */,
+			);
+			path = "push-sdk";
+			sourceTree = "<group>";
+		};
+		48289BE01B2EEDF2004AF471 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				48289BE11B2EEDF2004AF471 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		48289BEC1B2EEDF2004AF471 /* push-sdkTests */ = {
+			isa = PBXGroup;
+			children = (
+				48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */,
+				48289BED1B2EEDF2004AF471 /* Supporting Files */,
+			);
+			path = "push-sdkTests";
+			sourceTree = "<group>";
+		};
+		48289BED1B2EEDF2004AF471 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				48289BEE1B2EEDF2004AF471 /* Info.plist */,
+			);
+			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 		A010C2D81737A58100CFA575 = {
 			isa = PBXGroup;
 			children = (
-				A010C2E61737A58100CFA575 /* push-sdk */,
-				A010C2FB1737A58100CFA575 /* push-sdkTests */,
+				48289BDF1B2EEDF2004AF471 /* push-sdk */,
+				48289BEC1B2EEDF2004AF471 /* push-sdkTests */,
 				A010C2E31737A58100CFA575 /* Frameworks */,
 				A010C2E21737A58100CFA575 /* Products */,
 				26EAEE2BE45550C8D8056301 /* Pods */,
@@ -126,8 +146,8 @@
 		A010C2E21737A58100CFA575 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A010C2E11737A58100CFA575 /* libpush-sdk.a */,
-				A010C2F21737A58100CFA575 /* push-sdkTests.octest */,
+				48289BDE1B2EEDF2004AF471 /* pushsdk.framework */,
+				48289BE81B2EEDF2004AF471 /* push-sdkTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -144,101 +164,66 @@
 				A010C2F51737A58100CFA575 /* UIKit.framework */,
 				5F8A96B5477848779F501C0A /* libPods.a */,
 				690976179180479293B024D8 /* libPods-push-sdkTests.a */,
+				30277CD3D67E463A98C74ED2 /* libPods-pushsdkTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		A010C2E61737A58100CFA575 /* push-sdk */ = {
-			isa = PBXGroup;
-			children = (
-				A010C31E1737D20600CFA575 /* internal */,
-				A010C2E71737A58100CFA575 /* Supporting Files */,
-				A010C3101737A97A00CFA575 /* AeroGearPush.h */,
-				A010C3131737A9ED00CFA575 /* AGDeviceRegistration.h */,
-				A010C3141737A9ED00CFA575 /* AGDeviceRegistration.m */,
-				A010C3191737B09D00CFA575 /* AGClientDeviceInformation.h */,
-				482A24F01B0A18D500CE5BDC /* AGPushAnalytics.h */,
-				482A24EE1B0A189F00CE5BDC /* AGPushAnalytics.m */,
-			);
-			path = "push-sdk";
-			sourceTree = "<group>";
-		};
-		A010C2E71737A58100CFA575 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				A010C2E81737A58100CFA575 /* push-sdk-Prefix.pch */,
-				6FF89BEF18F572B000C19EE6 /* push-sdk-fmwk-info.plist */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		A010C2FB1737A58100CFA575 /* push-sdkTests */ = {
-			isa = PBXGroup;
-			children = (
-				A010C2FC1737A58100CFA575 /* Supporting Files */,
-				A010C3171737AA2C00CFA575 /* AGDeviceRegistrationSpec.m */,
-			);
-			path = "push-sdkTests";
-			sourceTree = "<group>";
-		};
-		A010C2FC1737A58100CFA575 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				A010C2FD1737A58100CFA575 /* push-sdkTests-Info.plist */,
-				A010C2FE1737A58100CFA575 /* InfoPlist.strings */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		A010C31E1737D20600CFA575 /* internal */ = {
-			isa = PBXGroup;
-			children = (
-				A010C31B1737D00F00CFA575 /* AGClientDeviceInformationImpl.h */,
-				A010C31C1737D00F00CFA575 /* AGClientDeviceInformationImpl.m */,
-			);
-			name = internal;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
-/* Begin PBXNativeTarget section */
-		A010C2E01737A58100CFA575 /* push-sdk */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = A010C3061737A58100CFA575 /* Build configuration list for PBXNativeTarget "push-sdk" */;
-			buildPhases = (
-				A010C2DD1737A58100CFA575 /* Sources */,
-				A010C2DE1737A58100CFA575 /* Frameworks */,
-				A010C2DF1737A58100CFA575 /* CopyFiles */,
-				891C018091B0491D9B8A8620 /* Copy Pods Resources */,
+/* Begin PBXHeadersBuildPhase section */
+		48289BDB1B2EEDF2004AF471 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				48289C011B2EEE5D004AF471 /* AGClientDeviceInformationImpl.h in Headers */,
+				48289BFF1B2EEE5D004AF471 /* AeroGearPush.h in Headers */,
+				48289C031B2EEE5D004AF471 /* AGDeviceRegistration.h in Headers */,
+				48289C051B2EEE5D004AF471 /* AGPushAnalytics.h in Headers */,
+				48289C001B2EEE5D004AF471 /* AGClientDeviceInformation.h in Headers */,
 			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "push-sdk";
-			productName = "push-sdk";
-			productReference = A010C2E11737A58100CFA575 /* libpush-sdk.a */;
-			productType = "com.apple.product-type.library.static";
+			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A010C2F11737A58100CFA575 /* push-sdkTests */ = {
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		48289BDD1B2EEDF2004AF471 /* pushsdk */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A010C3091737A58100CFA575 /* Build configuration list for PBXNativeTarget "push-sdkTests" */;
+			buildConfigurationList = 48289BF11B2EEDF2004AF471 /* Build configuration list for PBXNativeTarget "pushsdk" */;
 			buildPhases = (
-				A010C2ED1737A58100CFA575 /* Sources */,
-				A010C2EE1737A58100CFA575 /* Frameworks */,
-				A010C2EF1737A58100CFA575 /* Resources */,
-				A010C2F01737A58100CFA575 /* ShellScript */,
-				4D102FF221B4450E9369EF2E /* Copy Pods Resources */,
+				48289BD91B2EEDF2004AF471 /* Sources */,
+				48289BDA1B2EEDF2004AF471 /* Frameworks */,
+				48289BDB1B2EEDF2004AF471 /* Headers */,
+				48289BDC1B2EEDF2004AF471 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				A010C2F91737A58100CFA575 /* PBXTargetDependency */,
 			);
-			name = "push-sdkTests";
+			name = pushsdk;
+			productName = "push-sdk";
+			productReference = 48289BDE1B2EEDF2004AF471 /* pushsdk.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		48289BE71B2EEDF2004AF471 /* pushsdkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 48289BF41B2EEDF2004AF471 /* Build configuration list for PBXNativeTarget "pushsdkTests" */;
+			buildPhases = (
+				B7633F66FC8250F770B9B313 /* Check Pods Manifest.lock */,
+				48289BE41B2EEDF2004AF471 /* Sources */,
+				48289BE51B2EEDF2004AF471 /* Frameworks */,
+				48289BE61B2EEDF2004AF471 /* Resources */,
+				14A5211A3A2661B5D6FC2392 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				48289BEB1B2EEDF2004AF471 /* PBXTargetDependency */,
+			);
+			name = pushsdkTests;
 			productName = "push-sdkTests";
-			productReference = A010C2F21737A58100CFA575 /* push-sdkTests.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productReference = 48289BE81B2EEDF2004AF471 /* push-sdkTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -248,6 +233,14 @@
 			attributes = {
 				LastUpgradeCheck = 0460;
 				ORGANIZATIONNAME = "Red Hat";
+				TargetAttributes = {
+					48289BDD1B2EEDF2004AF471 = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+					48289BE71B2EEDF2004AF471 = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+				};
 			};
 			buildConfigurationList = A010C2DC1737A58100CFA575 /* Build configuration list for PBXProject "push-sdk" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -261,25 +254,31 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				A010C2E01737A58100CFA575 /* push-sdk */,
-				A010C2F11737A58100CFA575 /* push-sdkTests */,
+				48289BDD1B2EEDF2004AF471 /* pushsdk */,
+				48289BE71B2EEDF2004AF471 /* pushsdkTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		A010C2EF1737A58100CFA575 /* Resources */ = {
+		48289BDC1B2EEDF2004AF471 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A010C3001737A58100CFA575 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		48289BE61B2EEDF2004AF471 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		4D102FF221B4450E9369EF2E /* Copy Pods Resources */ = {
+		14A5211A3A2661B5D6FC2392 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -291,79 +290,198 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-push-sdkTests/Pods-push-sdkTests-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-pushsdkTests/Pods-pushsdkTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
-		891C018091B0491D9B8A8620 /* Copy Pods Resources */ = {
+		B7633F66FC8250F770B9B313 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "
-";
-		};
-		A010C2F01737A58100CFA575 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		A010C2DD1737A58100CFA575 /* Sources */ = {
+		48289BD91B2EEDF2004AF471 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				482A24EF1B0A189F00CE5BDC /* AGPushAnalytics.m in Sources */,
-				A010C3151737A9ED00CFA575 /* AGDeviceRegistration.m in Sources */,
-				A010C31D1737D01000CFA575 /* AGClientDeviceInformationImpl.m in Sources */,
+				48289C061B2EEE5D004AF471 /* AGPushAnalytics.m in Sources */,
+				48289C041B2EEE5D004AF471 /* AGDeviceRegistration.m in Sources */,
+				48289C021B2EEE5D004AF471 /* AGClientDeviceInformationImpl.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A010C2ED1737A58100CFA575 /* Sources */ = {
+		48289BE41B2EEDF2004AF471 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A010C3181737AA2C00CFA575 /* AGDeviceRegistrationSpec.m in Sources */,
+				48289C081B2EEE78004AF471 /* AGDeviceRegistrationSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		A010C2F91737A58100CFA575 /* PBXTargetDependency */ = {
+		48289BEB1B2EEDF2004AF471 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = A010C2E01737A58100CFA575 /* push-sdk */;
-			targetProxy = A010C2F81737A58100CFA575 /* PBXContainerItemProxy */;
+			target = 48289BDD1B2EEDF2004AF471 /* pushsdk */;
+			targetProxy = 48289BEA1B2EEDF2004AF471 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
-/* Begin PBXVariantGroup section */
-		A010C2FE1737A58100CFA575 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				A010C2FF1737A58100CFA575 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
 /* Begin XCBuildConfiguration section */
+		48289BF21B2EEDF2004AF471 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "push-sdk/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		48289BF31B2EEDF2004AF471 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "push-sdk/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		48289BF51B2EEDF2004AF471 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 881341938EC0FF4FED20F1A4 /* Pods-pushsdkTests.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "push-sdkTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		48289BF61B2EEDF2004AF471 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 99807EBAD8048D94D8FF85A9 /* Pods-pushsdkTests.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "push-sdkTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		A010C3041737A58100CFA575 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -417,90 +535,32 @@
 			};
 			name = Release;
 		};
-		A010C3071737A58100CFA575 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DSTROOT = /tmp/push_sdk.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "push-sdk/push-sdk-Prefix.pch";
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		A010C3081737A58100CFA575 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DSTROOT = /tmp/push_sdk.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "push-sdk/push-sdk-Prefix.pch";
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		A010C30A1737A58100CFA575 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8564B376890B868A05FBA59D /* Pods-push-sdkTests.debug.xcconfig */;
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
-					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
-					"\"$(PLATFORM_DIR)/Developer/Library/Frameworks\"\n\n",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "push-sdk/push-sdk-Prefix.pch";
-				INFOPLIST_FILE = "push-sdkTests/push-sdkTests-Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Debug;
-		};
-		A010C30B1737A58100CFA575 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3BFACB4DBB32DE6AB10BCA68 /* Pods-push-sdkTests.release.xcconfig */;
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
-					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
-					"\"$(PLATFORM_DIR)/Developer/Library/Frameworks\"\n\n",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "push-sdk/push-sdk-Prefix.pch";
-				INFOPLIST_FILE = "push-sdkTests/push-sdkTests-Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		48289BF11B2EEDF2004AF471 /* Build configuration list for PBXNativeTarget "pushsdk" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				48289BF21B2EEDF2004AF471 /* Debug */,
+				48289BF31B2EEDF2004AF471 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		48289BF41B2EEDF2004AF471 /* Build configuration list for PBXNativeTarget "pushsdkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				48289BF51B2EEDF2004AF471 /* Debug */,
+				48289BF61B2EEDF2004AF471 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A010C2DC1737A58100CFA575 /* Build configuration list for PBXProject "push-sdk" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A010C3041737A58100CFA575 /* Debug */,
 				A010C3051737A58100CFA575 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		A010C3061737A58100CFA575 /* Build configuration list for PBXNativeTarget "push-sdk" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A010C3071737A58100CFA575 /* Debug */,
-				A010C3081737A58100CFA575 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		A010C3091737A58100CFA575 /* Build configuration list for PBXNativeTarget "push-sdkTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A010C30A1737A58100CFA575 /* Debug */,
-				A010C30B1737A58100CFA575 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/push-sdk.xcodeproj/project.pbxproj
+++ b/push-sdk.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		48289C051B2EEE5D004AF471 /* AGPushAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 48289BFD1B2EEE5D004AF471 /* AGPushAnalytics.h */; };
 		48289C061B2EEE5D004AF471 /* AGPushAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */; };
 		48289C081B2EEE78004AF471 /* AGDeviceRegistrationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */; };
+		48289C0D1B2EF25C004AF471 /* AGPushAnalyticsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289C0C1B2EF25C004AF471 /* AGPushAnalyticsSpec.m */; };
 		5C18F90CC0E512A66E4B5789 /* libPods-pushsdkTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 30277CD3D67E463A98C74ED2 /* libPods-pushsdkTests.a */; };
 /* End PBXBuildFile section */
 
@@ -46,6 +47,7 @@
 		48289BFD1B2EEE5D004AF471 /* AGPushAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGPushAnalytics.h; sourceTree = "<group>"; };
 		48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGPushAnalytics.m; sourceTree = "<group>"; };
 		48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGDeviceRegistrationSpec.m; sourceTree = "<group>"; };
+		48289C0C1B2EF25C004AF471 /* AGPushAnalyticsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGPushAnalyticsSpec.m; sourceTree = "<group>"; };
 		5F8A96B5477848779F501C0A /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		690976179180479293B024D8 /* libPods-push-sdkTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-push-sdkTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F53E2BA1768A935001966D8 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -119,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */,
+				48289C0C1B2EF25C004AF471 /* AGPushAnalyticsSpec.m */,
 				48289BED1B2EEDF2004AF471 /* Supporting Files */,
 			);
 			path = "push-sdkTests";
@@ -326,6 +329,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				48289C081B2EEE78004AF471 /* AGDeviceRegistrationSpec.m in Sources */,
+				48289C0D1B2EF25C004AF471 /* AGPushAnalyticsSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/push-sdk.xcodeproj/project.pbxproj
+++ b/push-sdk.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		48289C061B2EEE5D004AF471 /* AGPushAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */; };
 		48289C081B2EEE78004AF471 /* AGDeviceRegistrationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */; };
 		48289C0D1B2EF25C004AF471 /* AGPushAnalyticsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289C0C1B2EF25C004AF471 /* AGPushAnalyticsSpec.m */; };
+		48289C551B2F082A004AF471 /* libpush-sdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 48289C4A1B2F082A004AF471 /* libpush-sdk.a */; };
+		48289C611B2F0859004AF471 /* AGClientDeviceInformationImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFA1B2EEE5D004AF471 /* AGClientDeviceInformationImpl.m */; };
+		48289C621B2F0859004AF471 /* AGDeviceRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFC1B2EEE5D004AF471 /* AGDeviceRegistration.m */; };
+		48289C631B2F0859004AF471 /* AGPushAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */; };
 		5C18F90CC0E512A66E4B5789 /* libPods-pushsdkTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 30277CD3D67E463A98C74ED2 /* libPods-pushsdkTests.a */; };
 /* End PBXBuildFile section */
 
@@ -29,14 +33,33 @@
 			remoteGlobalIDString = 48289BDD1B2EEDF2004AF471;
 			remoteInfo = "push-sdk";
 		};
+		48289C561B2F082A004AF471 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A010C2D91737A58100CFA575 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 48289C491B2F082A004AF471;
+			remoteInfo = "push-sdk";
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		48289C481B2F082A004AF471 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		30277CD3D67E463A98C74ED2 /* libPods-pushsdkTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-pushsdkTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BFACB4DBB32DE6AB10BCA68 /* Pods-push-sdkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-push-sdkTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-push-sdkTests/Pods-push-sdkTests.release.xcconfig"; sourceTree = "<group>"; };
 		48289BDE1B2EEDF2004AF471 /* pushsdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = pushsdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		48289BE11B2EEDF2004AF471 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		48289BE81B2EEDF2004AF471 /* push-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "push-sdkTests.xctest"; path = pushsdkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		48289BE81B2EEDF2004AF471 /* pushsdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = pushsdkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		48289BEE1B2EEDF2004AF471 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		48289BF71B2EEE5D004AF471 /* AeroGearPush.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AeroGearPush.h; sourceTree = "<group>"; };
 		48289BF81B2EEE5D004AF471 /* AGClientDeviceInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGClientDeviceInformation.h; sourceTree = "<group>"; };
@@ -48,6 +71,8 @@
 		48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGPushAnalytics.m; sourceTree = "<group>"; };
 		48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGDeviceRegistrationSpec.m; sourceTree = "<group>"; };
 		48289C0C1B2EF25C004AF471 /* AGPushAnalyticsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGPushAnalyticsSpec.m; sourceTree = "<group>"; };
+		48289C4A1B2F082A004AF471 /* libpush-sdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libpush-sdk.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		48289C541B2F082A004AF471 /* push-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "push-sdkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F8A96B5477848779F501C0A /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		690976179180479293B024D8 /* libPods-push-sdkTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-push-sdkTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F53E2BA1768A935001966D8 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -76,6 +101,21 @@
 			files = (
 				48289BE91B2EEDF2004AF471 /* pushsdk.framework in Frameworks */,
 				5C18F90CC0E512A66E4B5789 /* libPods-pushsdkTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		48289C471B2F082A004AF471 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		48289C511B2F082A004AF471 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				48289C551B2F082A004AF471 /* libpush-sdk.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -150,7 +190,9 @@
 			isa = PBXGroup;
 			children = (
 				48289BDE1B2EEDF2004AF471 /* pushsdk.framework */,
-				48289BE81B2EEDF2004AF471 /* push-sdkTests.xctest */,
+				48289BE81B2EEDF2004AF471 /* pushsdkTests.xctest */,
+				48289C4A1B2F082A004AF471 /* libpush-sdk.a */,
+				48289C541B2F082A004AF471 /* push-sdkTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -225,7 +267,42 @@
 			);
 			name = pushsdkTests;
 			productName = "push-sdkTests";
-			productReference = 48289BE81B2EEDF2004AF471 /* push-sdkTests.xctest */;
+			productReference = 48289BE81B2EEDF2004AF471 /* pushsdkTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		48289C491B2F082A004AF471 /* push-sdk */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 48289C5F1B2F082A004AF471 /* Build configuration list for PBXNativeTarget "push-sdk" */;
+			buildPhases = (
+				48289C461B2F082A004AF471 /* Sources */,
+				48289C471B2F082A004AF471 /* Frameworks */,
+				48289C481B2F082A004AF471 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "push-sdk";
+			productName = "push-sdk";
+			productReference = 48289C4A1B2F082A004AF471 /* libpush-sdk.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		48289C531B2F082A004AF471 /* push-sdkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 48289C601B2F082A004AF471 /* Build configuration list for PBXNativeTarget "push-sdkTests" */;
+			buildPhases = (
+				48289C501B2F082A004AF471 /* Sources */,
+				48289C511B2F082A004AF471 /* Frameworks */,
+				48289C521B2F082A004AF471 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				48289C571B2F082A004AF471 /* PBXTargetDependency */,
+			);
+			name = "push-sdkTests";
+			productName = "push-sdkTests";
+			productReference = 48289C541B2F082A004AF471 /* push-sdkTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -241,6 +318,12 @@
 						CreatedOnToolsVersion = 6.3.2;
 					};
 					48289BE71B2EEDF2004AF471 = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+					48289C491B2F082A004AF471 = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+					48289C531B2F082A004AF471 = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
 				};
@@ -259,6 +342,8 @@
 			targets = (
 				48289BDD1B2EEDF2004AF471 /* pushsdk */,
 				48289BE71B2EEDF2004AF471 /* pushsdkTests */,
+				48289C491B2F082A004AF471 /* push-sdk */,
+				48289C531B2F082A004AF471 /* push-sdkTests */,
 			);
 		};
 /* End PBXProject section */
@@ -272,6 +357,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		48289BE61B2EEDF2004AF471 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		48289C521B2F082A004AF471 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -333,6 +425,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		48289C461B2F082A004AF471 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				48289C611B2F0859004AF471 /* AGClientDeviceInformationImpl.m in Sources */,
+				48289C621B2F0859004AF471 /* AGDeviceRegistration.m in Sources */,
+				48289C631B2F0859004AF471 /* AGPushAnalytics.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		48289C501B2F082A004AF471 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -340,6 +449,11 @@
 			isa = PBXTargetDependency;
 			target = 48289BDD1B2EEDF2004AF471 /* pushsdk */;
 			targetProxy = 48289BEA1B2EEDF2004AF471 /* PBXContainerItemProxy */;
+		};
+		48289C571B2F082A004AF471 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 48289C491B2F082A004AF471 /* push-sdk */;
+			targetProxy = 48289C561B2F082A004AF471 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -486,6 +600,124 @@
 			};
 			name = Release;
 		};
+		48289C5B1B2F082A004AF471 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		48289C5C1B2F082A004AF471 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		48289C5D1B2F082A004AF471 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "push-sdkTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		48289C5E1B2F082A004AF471 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "push-sdkTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		A010C3041737A58100CFA575 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -559,6 +791,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		48289C5F1B2F082A004AF471 /* Build configuration list for PBXNativeTarget "push-sdk" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				48289C5B1B2F082A004AF471 /* Debug */,
+				48289C5C1B2F082A004AF471 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		48289C601B2F082A004AF471 /* Build configuration list for PBXNativeTarget "push-sdkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				48289C5D1B2F082A004AF471 /* Debug */,
+				48289C5E1B2F082A004AF471 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		A010C2DC1737A58100CFA575 /* Build configuration list for PBXProject "push-sdk" */ = {
 			isa = XCConfigurationList;

--- a/push-sdk.xcodeproj/project.pbxproj
+++ b/push-sdk.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		48289C061B2EEE5D004AF471 /* AGPushAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */; };
 		48289C081B2EEE78004AF471 /* AGDeviceRegistrationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */; };
 		48289C0D1B2EF25C004AF471 /* AGPushAnalyticsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289C0C1B2EF25C004AF471 /* AGPushAnalyticsSpec.m */; };
-		48289C551B2F082A004AF471 /* libpush-sdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 48289C4A1B2F082A004AF471 /* libpush-sdk.a */; };
 		48289C611B2F0859004AF471 /* AGClientDeviceInformationImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFA1B2EEE5D004AF471 /* AGClientDeviceInformationImpl.m */; };
 		48289C621B2F0859004AF471 /* AGDeviceRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFC1B2EEE5D004AF471 /* AGDeviceRegistration.m */; };
 		48289C631B2F0859004AF471 /* AGPushAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 48289BFE1B2EEE5D004AF471 /* AGPushAnalytics.m */; };
@@ -31,13 +30,6 @@
 			containerPortal = A010C2D91737A58100CFA575 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 48289BDD1B2EEDF2004AF471;
-			remoteInfo = "push-sdk";
-		};
-		48289C561B2F082A004AF471 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A010C2D91737A58100CFA575 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 48289C491B2F082A004AF471;
 			remoteInfo = "push-sdk";
 		};
 /* End PBXContainerItemProxy section */
@@ -72,7 +64,6 @@
 		48289C071B2EEE78004AF471 /* AGDeviceRegistrationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGDeviceRegistrationSpec.m; sourceTree = "<group>"; };
 		48289C0C1B2EF25C004AF471 /* AGPushAnalyticsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGPushAnalyticsSpec.m; sourceTree = "<group>"; };
 		48289C4A1B2F082A004AF471 /* libpush-sdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libpush-sdk.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		48289C541B2F082A004AF471 /* push-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "push-sdkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F8A96B5477848779F501C0A /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		690976179180479293B024D8 /* libPods-push-sdkTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-push-sdkTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F53E2BA1768A935001966D8 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -108,14 +99,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		48289C511B2F082A004AF471 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				48289C551B2F082A004AF471 /* libpush-sdk.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,7 +175,6 @@
 				48289BDE1B2EEDF2004AF471 /* pushsdk.framework */,
 				48289BE81B2EEDF2004AF471 /* pushsdkTests.xctest */,
 				48289C4A1B2F082A004AF471 /* libpush-sdk.a */,
-				48289C541B2F082A004AF471 /* push-sdkTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -287,24 +269,6 @@
 			productReference = 48289C4A1B2F082A004AF471 /* libpush-sdk.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		48289C531B2F082A004AF471 /* push-sdkTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 48289C601B2F082A004AF471 /* Build configuration list for PBXNativeTarget "push-sdkTests" */;
-			buildPhases = (
-				48289C501B2F082A004AF471 /* Sources */,
-				48289C511B2F082A004AF471 /* Frameworks */,
-				48289C521B2F082A004AF471 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				48289C571B2F082A004AF471 /* PBXTargetDependency */,
-			);
-			name = "push-sdkTests";
-			productName = "push-sdkTests";
-			productReference = 48289C541B2F082A004AF471 /* push-sdkTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -321,9 +285,6 @@
 						CreatedOnToolsVersion = 6.3.2;
 					};
 					48289C491B2F082A004AF471 = {
-						CreatedOnToolsVersion = 6.3.2;
-					};
-					48289C531B2F082A004AF471 = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
 				};
@@ -343,7 +304,6 @@
 				48289BDD1B2EEDF2004AF471 /* pushsdk */,
 				48289BE71B2EEDF2004AF471 /* pushsdkTests */,
 				48289C491B2F082A004AF471 /* push-sdk */,
-				48289C531B2F082A004AF471 /* push-sdkTests */,
 			);
 		};
 /* End PBXProject section */
@@ -357,13 +317,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		48289BE61B2EEDF2004AF471 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		48289C521B2F082A004AF471 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -435,13 +388,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		48289C501B2F082A004AF471 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -449,11 +395,6 @@
 			isa = PBXTargetDependency;
 			target = 48289BDD1B2EEDF2004AF471 /* pushsdk */;
 			targetProxy = 48289BEA1B2EEDF2004AF471 /* PBXContainerItemProxy */;
-		};
-		48289C571B2F082A004AF471 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 48289C491B2F082A004AF471 /* push-sdk */;
-			targetProxy = 48289C561B2F082A004AF471 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -654,70 +595,6 @@
 			};
 			name = Release;
 		};
-		48289C5D1B2F082A004AF471 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				INFOPLIST_FILE = "push-sdkTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Debug;
-		};
-		48289C5E1B2F082A004AF471 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				INFOPLIST_FILE = "push-sdkTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
 		A010C3041737A58100CFA575 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -799,14 +676,7 @@
 				48289C5C1B2F082A004AF471 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-		};
-		48289C601B2F082A004AF471 /* Build configuration list for PBXNativeTarget "push-sdkTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				48289C5D1B2F082A004AF471 /* Debug */,
-				48289C5E1B2F082A004AF471 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		A010C2DC1737A58100CFA575 /* Build configuration list for PBXProject "push-sdk" */ = {
 			isa = XCConfigurationList;

--- a/push-sdk.xcodeproj/xcshareddata/xcschemes/push-sdk.xcscheme
+++ b/push-sdk.xcodeproj/xcshareddata/xcschemes/push-sdk.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A010C2E01737A58100CFA575"
-               BuildableName = "libpush-sdk.a"
-               BlueprintName = "push-sdk"
+               BlueprintIdentifier = "48289BDD1B2EEDF2004AF471"
+               BuildableName = "pushsdk.framework"
+               BlueprintName = "pushsdk"
                ReferencedContainer = "container:push-sdk.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,9 +32,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A010C2F11737A58100CFA575"
-               BuildableName = "push-sdkTests.octest"
-               BlueprintName = "push-sdkTests"
+               BlueprintIdentifier = "48289BE71B2EEDF2004AF471"
+               BuildableName = "pushsdkTests.xctest"
+               BlueprintName = "pushsdkTests"
                ReferencedContainer = "container:push-sdk.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -49,6 +49,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "48289BDD1B2EEDF2004AF471"
+            BuildableName = "pushsdk.framework"
+            BlueprintName = "pushsdk"
+            ReferencedContainer = "container:push-sdk.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/push-sdk/Info.plist
+++ b/push-sdk/Info.plist
@@ -5,18 +5,22 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.aerogear.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>org.aerogear.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>BNDL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/push-sdkTests/AGPushAnalyticsSpec.m
+++ b/push-sdkTests/AGPushAnalyticsSpec.m
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#import <Kiwi/Kiwi.h>
+#import "OHHTTPStubs.h"
+#import "OHHTTPStubsResponse.h"
+
+
+#import "AGPushAnalytics.h"
+
+
+SPEC_BEGIN(AGPushAnalyticsSpec)
+
+
+describe(@"AGPushAnalytics", ^{
+    
+    context(@"send metrics...", ^{
+        
+        
+        it(@"successfully", ^{
+            [[NSUserDefaults standardUserDefaults] setValue:@"VARIANT" forKey:@"variantID"];
+            [[NSUserDefaults standardUserDefaults] setValue:@"SECRET" forKey:@"variantSecret"];
+            [[NSUserDefaults standardUserDefaults] setValue:@"http://server.com" forKey:@"serverURL"];
+            
+            // install the mock:
+            [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+                return YES;
+            } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+
+                    return [[OHHTTPStubsResponse responseWithData:[NSData data]
+                                                       statusCode:200
+                                                          headers:@{@"Content-Type":@"text/json]"}] responseTime:0];
+
+            }];
+            NSDictionary* options = @{UIApplicationLaunchOptionsRemoteNotificationKey: @{@"aerogear-push-id":@"123456"} };
+           
+            
+            [AGPushAnalytics sendMetricsWhenAppLaunched:options completionHandler:^(NSError *error) {
+                [error shouldBeNil];
+            }];
+        });
+        
+        it(@"should fail to register if configuration block is not set", ^{
+            [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"variantID"];
+            [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"variantSecret"];
+            [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"serverURL"];
+            
+            // install the mock:
+            [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+                return YES;
+            } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+                
+                return [[OHHTTPStubsResponse responseWithData:[NSData data]
+                                                   statusCode:200
+                                                      headers:@{@"Content-Type":@"text/json]"}] responseTime:0];
+                
+            }];
+            NSDictionary* options = @{UIApplicationLaunchOptionsRemoteNotificationKey: @{@"aerogear-push-id":@"123456"} };
+            
+            
+            [AGPushAnalytics sendMetricsWhenAppLaunched:options completionHandler:^(NSError *error) {
+                [error shouldNotBeNil];
+            }];
+
+        });
+    });
+});
+
+SPEC_END

--- a/push-sdkTests/Info.plist
+++ b/push-sdkTests/Info.plist
@@ -5,18 +5,20 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.aerogear.${PRODUCT_NAME}</string>
+	<string>org.aerogear.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
+	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>1</string>
 </dict>
 </plist>


### PR DESCRIPTION
AGIOS-449 + AGIOS-448
Since Xcode 6.3 unit test execution was broken.
This PR regenerate the test target for latest xcode + add missing ObjC test for AGPushAnalytics

TO BE MERGED in 1.x_dev