### PR TITLE
Objc.store.device.token

### DIFF
--- a/AeroGear-Push.podspec
+++ b/AeroGear-Push.podspec
@@ -8,5 +8,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aerogear/aerogear-ios-push.git', :tag => '1.1.0-beta.1' }
   s.platform     = :ios, 7.0
   s.source_files = 'push-sdk/**/*.{h,m}'
+  s.public_header_files = 'push-sdk/AeroGearPush.h', 'push-sdk/AGDeviceRegistration.h', 'push-sdk/AGClientDeviceInformation.h', 'push-sdk/AGPushAnalytics.h'
   s.requires_arc = true
 end

--- a/AeroGear-Push.podspec
+++ b/AeroGear-Push.podspec
@@ -8,6 +8,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aerogear/aerogear-ios-push.git', :tag => '1.1.0-beta.1' }
   s.platform     = :ios, 7.0
   s.source_files = 'push-sdk/**/*.{h,m}'
-  s.public_header_files = 'push-sdk/AeroGearPush.h', 'push-sdk/AGDeviceRegistration.h', 'push-sdk/AGClientDeviceInformation.h'
   s.requires_arc = true
 end

--- a/push-sdk/AGDeviceRegistration.m
+++ b/push-sdk/AGDeviceRegistration.m
@@ -53,18 +53,7 @@ static AGDeviceRegistration* sharedInstance;
 }
 
 -(id) init {
-    self = [super init];
-    if (self) {
-        // initialize session
-        NSURLSessionConfiguration *sessionConfig =
-        [NSURLSessionConfiguration defaultSessionConfiguration];
-        
-        _session = [NSURLSession sessionWithConfiguration:sessionConfig delegate:self delegateQueue:[NSOperationQueue mainQueue]];
-        
-        sharedInstance = self;
-    }
-    
-    return self;
+    return [self initWithFile:nil];
 }
 
 -(id) initWithFile:(NSString*)configFile {
@@ -119,6 +108,7 @@ static AGDeviceRegistration* sharedInstance;
     NSAssert(clientInfoObject.variantSecret, @"'variantSecret' should be set");
     
     // locally stored information
+    [[NSUserDefaults standardUserDefaults] setObject: clientInfoObject.deviceToken forKey: @"deviceToken"];
     [[NSUserDefaults standardUserDefaults] setObject: clientInfoObject.variantID forKey: @"variantID"];
     [[NSUserDefaults standardUserDefaults] setObject: clientInfoObject.variantSecret forKey: @"variantSecret"];
     [[NSUserDefaults standardUserDefaults] setObject: _baseURL.absoluteString forKey: @"serverURL"];

--- a/push-sdk/AGDeviceRegistration.m
+++ b/push-sdk/AGDeviceRegistration.m
@@ -103,6 +103,12 @@ static AGDeviceRegistration* sharedInstance;
         }
     }
     
+    // deviceToken could be nil then retrieved it from local storage (from previous register).
+    // This is the use case when you update categories.
+    if (clientInfoObject.deviceToken == nil) {
+        clientInfoObject.deviceToken =  [[NSUserDefaults standardUserDefaults] objectForKey:@"deviceToken"];
+    }
+    
     NSAssert(clientInfoObject.deviceToken, @"'token' should be set");
     NSAssert(clientInfoObject.variantID, @"'variantID' should be set");
     NSAssert(clientInfoObject.variantSecret, @"'variantSecret' should be set");


### PR DESCRIPTION
this PR:
- store deviceToken, for later if the user wants to update the categories without having deviceToken (in another flow than AppDelegate)
- fix cocoapods spec adding AGPushAnalytics.h