### PR TITLE
fix reading properties file

### DIFF
--- a/push-sdk-swift/AGDeviceRegistration.swift
+++ b/push-sdk-swift/AGDeviceRegistration.swift
@@ -212,7 +212,7 @@ public class AGDeviceRegistration: NSObject, NSURLSessionTaskDelegate {
     private func configValueForKey(key: String) -> String? {
         var value: String?
         if let config = self.config { // specified plist config file
-            let path = NSBundle(forClass: AGDeviceRegistration.self).pathForResource(config, ofType:"plist")
+            let path = NSBundle.mainBundle().pathForResource(config, ofType: "plist")
             var properties = NSMutableDictionary(contentsOfFile: path!)
             if let properties = properties {
                 value = properties[key as String] as? String


### PR DESCRIPTION
To fix a AGIOS-477 making possible to read  named properties file to hold push config.
This PR can be tested with HelloWorld app.
https://github.com/jboss-mobile/unified-push-helloworld/pull/19