### PR TITLE
fix: Change s.source, s.homepage and s.version (RHMAP-22020)

### DIFF
--- a/AeroGearPush-Sw.podspec
+++ b/AeroGearPush-Sw.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
-  s.name         = "AeroGearPush-Sw"
-  s.version      = "3.0.7"
+  s.name         = "AeroGearPush-Swift"
+  s.version      = "3.0.1"
   s.summary      = "AeroGear UnifiedPush Client Registration SDK (Swift)."
-  s.homepage     = "https://github.com/coco-jam/aerogear-ios-push"
+  s.homepage     = "https://github.com/aerogear/aerogear-ios-push/"
   s.license      = 'Apache License, Version 2.0'
   s.author       = "Red Hat, Inc."
-  s.source       = { :git => 'https://github.com/coco-jam/aerogear-ios-push.git', :tag => s.version }
+  s.source       = { :git => 'https://github.com/aerogear/aerogear-ios-push.git', :branch => 'Swift4.2' }
   s.platform     = :ios, 9.0
   s.source_files = 'AeroGearPush/*.{swift}'
   s.module_name  = "AeroGearPush"


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/RHMAP-22020

## What
updating the s.source ,s.homepage and s.version on the Swift4.2

## Why
Should be pointing at aerogear and version bump is not consistent with master

## How
update `AeroGearPush-Sw.podspec`

