### PR TITLE
fix devicetoken retrieval for IOS13. This is compatible to IOS 12 too

### DIFF
--- a/AeroGearPush/ClientDeviceInformationImpl.swift
+++ b/AeroGearPush/ClientDeviceInformationImpl.swift
@@ -50,13 +50,18 @@ class ClientDeviceInformationImpl: NSObject, ClientDeviceInformation {
 
     // Helper to transform the Data-based token into a (useful) String:
     fileprivate func convertToString(_ deviceToken: Data?) -> String? {
-        if let token = (deviceToken as NSData?)?.description {
-            return token.replacingOccurrences(of: "<", with: "")
-                .replacingOccurrences(of: ">", with: "")
-                .replacingOccurrences(of: " ", with: "")
-        }
-        
-        return nil
-    }
+            NSUInteger dataLength = deviceToken.length;
+            if (dataLength == 0) {
+                return nil;
+            }
+            
+            const unsigned char *dataBuffer = (const unsigned char *)deviceToken.bytes;
+            NSMutableString *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
 
+            for (int i = 0; i < dataLength; ++i) {
+                [hexString appendFormat:@"%02x", dataBuffer[i]];
+            }
+
+            return [hexString copy];
+    }
 }


### PR DESCRIPTION
## Motivation
IOS 13 changed its implementation of deviceToken.

## What
Add an short answer for: What was done in this PR? 
Converting to hexstring by not using deviceToken description field

## Why
Add an short answer for: Why it was done? 
previous implementation of deviceToken description is changed now. 

## How
Add an short answer for: How it was done? 
Not using description anymore

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Try registering for push notification on your unified push sever
2. after making this change you can see device will be registered fine
3. You can then try sending a push notification to it.

## Checklist:

- [YES ] Code has been tested locally by PR requester
- [ YES] Changes have been successfully verified by another team member 

## Progress

- [YES] Finished task
- [NO ] TODO



