### PR TITLE
fix devicetoken retrieval for IOS13. This is compatible to IOS 12 too [for 1.x_dev]

### DIFF
--- a/push-sdk/AGClientDeviceInformationImpl.m
+++ b/push-sdk/AGClientDeviceInformationImpl.m
@@ -59,12 +59,19 @@
 
 // little helper to transform the NSData-based token into a (useful) String:
 - (NSString *) convertToNSString:(NSData *)deviceToken {
-    NSString *tokenStr = [deviceToken description];
-    NSString *pushToken = [[[tokenStr
-                             stringByReplacingOccurrencesOfString:@"<" withString:@""]
-                            stringByReplacingOccurrencesOfString:@">" withString:@""]
-                           stringByReplacingOccurrencesOfString:@" " withString:@""];
-    return pushToken;
+    NSUInteger dataLength = deviceToken.length;
+    if (dataLength == 0) {
+        return nil;
+    }
+    
+    const unsigned char *dataBuffer = (const unsigned char *)deviceToken.bytes;
+    NSMutableString *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
+
+    for (int i = 0; i < dataLength; ++i) {
+        [hexString appendFormat:@"%02x", dataBuffer[i]];
+    }
+
+    return [hexString copy];
 }
 
 @end


### PR DESCRIPTION
## Motivation
IOS 13 changed its implementation of deviceToken.

## What
Add an short answer for: What was done in this PR? 
Converting to hexstring by not using deviceToken description field

## Why
Add an short answer for: Why it was done? 
previous implementation of deviceToken description is changed now. 

## How
Add an short answer for: How it was done? 
Not using description anymore

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Try registering for push notification on your unified push sever
2. after making this change you can see device will be registered fine
3. You can then try sending a push notification to it.



## Progress

- [YES] Finished task
- [NO ] TODO
